### PR TITLE
Create reusable MugenMenu component

### DIFF
--- a/Notepad.html
+++ b/Notepad.html
@@ -9,40 +9,7 @@
     <link rel="stylesheet" href="css/master.css">
 </head>
 <body class="app-page">
-    <!-- Hamburger Menu -->
-    <div class="hamburger-menu" id="hamburgerMenu">
-        <div class="hamburger" id="hamburger">
-            <span></span>
-            <span></span>
-            <span></span>
-        </div>
-    </div>
-
-    <!-- Sidebar Navigation -->
-    <div class="sidebar-overlay" id="sidebarOverlay"></div>
-    <nav class="sidebar" id="sidebar">
-        <div class="sidebar-header">
-            <div class="sidebar-logo">MugenOs</div>
-            <div class="sidebar-subtitle">無限 Sistema</div>
-        </div>
-        <div class="nav-menu">
-            <a href="index.html" class="nav-item" id="nav-home">
-                <i>🏠</i> Início
-            </a>
-            <a href="Notepad.html" class="nav-item active" id="nav-notepad">
-                <i>📝</i> Anotações
-            </a>
-            <a href="Project.html" class="nav-item" id="nav-projects">
-                <i>📋</i> Projetos
-            </a>
-            <a href="#" class="nav-item" id="nav-expenses" style="opacity: 0.5; pointer-events: none;">
-                <i>💰</i> Despesas <small>(em breve)</small>
-            </a>
-            <a href="#" class="nav-item" id="nav-calendar" style="opacity: 0.5; pointer-events: none;">
-                <i>📅</i> Compromissos <small>(em breve)</small>
-            </a>
-        </div>
-    </nav>
+    <mugen-menu></mugen-menu>
 
     <!-- Main Content -->
     <div class="main-content">
@@ -73,6 +40,7 @@
             </div>
         </div>
     </div>
+    <script src="components/mugen-menu.js"></script>
     <script src="js/app.js" defer></script>
 
 </body>

--- a/Project.html
+++ b/Project.html
@@ -9,40 +9,7 @@
     <link rel="stylesheet" href="css/master.css">
 </head>
 <body class="app-page">
-    <!-- Hamburger Menu -->
-    <div class="hamburger-menu" id="hamburgerMenu">
-        <div class="hamburger" id="hamburger">
-            <span></span>
-            <span></span>
-            <span></span>
-        </div>
-    </div>
-
-    <!-- Sidebar Navigation -->
-    <div class="sidebar-overlay" id="sidebarOverlay"></div>
-    <nav class="sidebar" id="sidebar">
-        <div class="sidebar-header">
-            <div class="sidebar-logo">MugenOs</div>
-            <div class="sidebar-subtitle">無限 Sistema</div>
-        </div>
-        <div class="nav-menu">
-            <a href="index.html" class="nav-item" id="nav-home">
-                <i>🏠</i> Início
-            </a>
-            <a href="Notepad.html" class="nav-item" id="nav-notepad">
-                <i>📝</i> Anotações
-            </a>
-            <a href="Project.html" class="nav-item active" id="nav-projects">
-                <i>📋</i> Projetos
-            </a>
-            <a href="#" class="nav-item" id="nav-expenses" style="opacity: 0.5; pointer-events: none;">
-                <i>💰</i> Despesas <small>(em breve)</small>
-            </a>
-            <a href="#" class="nav-item" id="nav-calendar" style="opacity: 0.5; pointer-events: none;">
-                <i>📅</i> Compromissos <small>(em breve)</small>
-            </a>
-        </div>
-    </nav>
+    <mugen-menu></mugen-menu>
 
     <!-- Main Content -->
     <div class="main-content">
@@ -110,6 +77,7 @@
             </form>
         </div>
     </div>
+    <script src="components/mugen-menu.js"></script>
     <script src="js/app.js" defer></script>
 
 </body>

--- a/components/mugen-menu.js
+++ b/components/mugen-menu.js
@@ -1,0 +1,107 @@
+class MugenMenu extends HTMLElement {
+  connectedCallback() {
+    if (this._initialized) return;
+    this._initialized = true;
+    this.innerHTML = `
+    <!-- Hamburger Menu -->
+    <div class="hamburger-menu" id="hamburgerMenu">
+        <div class="hamburger" id="hamburger">
+            <span></span>
+            <span></span>
+            <span></span>
+        </div>
+    </div>
+
+    <!-- Sidebar Navigation -->
+    <div class="sidebar-overlay" id="sidebarOverlay"></div>
+    <nav class="sidebar" id="sidebar">
+        <div class="sidebar-header">
+            <div class="sidebar-logo">MugenOs</div>
+            <div class="sidebar-subtitle">無限 Sistema</div>
+        </div>
+        <div class="nav-menu">
+            <a href="index.html" class="nav-item" id="nav-home">
+                <i>🏠</i> Início
+            </a>
+            <a href="Notepad.html" class="nav-item" id="nav-notepad">
+                <i>📝</i> Anotações
+            </a>
+            <a href="Project.html" class="nav-item" id="nav-projects">
+                <i>📋</i> Projetos
+            </a>
+            <a href="#" class="nav-item" id="nav-expenses" style="opacity: 0.5; pointer-events: none;">
+                <i>💰</i> Despesas <small>(em breve)</small>
+            </a>
+            <a href="#" class="nav-item" id="nav-calendar" style="opacity: 0.5; pointer-events: none;">
+                <i>📅</i> Compromissos <small>(em breve)</small>
+            </a>
+        </div>
+    </nav>`;
+    this.cacheDOM();
+    this.bindEvents();
+    this.setActiveNav();
+  }
+
+  cacheDOM() {
+    this.hamburgerMenu = this.querySelector('#hamburgerMenu');
+    this.hamburger = this.querySelector('#hamburger');
+    this.sidebar = this.querySelector('#sidebar');
+    this.overlay = this.querySelector('#sidebarOverlay');
+    this.navItems = this.querySelectorAll('.nav-item');
+  }
+
+  bindEvents() {
+    if (!this.hamburgerMenu) return;
+    this.hamburgerMenu.addEventListener('click', () => this.toggleSidebar());
+    this.overlay.addEventListener('click', () => this.closeSidebar());
+    this.navItems.forEach(item => {
+      item.addEventListener('click', () => {
+        if (!item.style.pointerEvents) this.closeSidebar();
+      });
+    });
+    this._handleKeyDown = (e) => {
+      if (e.key === 'Escape') this.closeSidebar();
+    };
+    document.addEventListener('keydown', this._handleKeyDown);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('keydown', this._handleKeyDown);
+  }
+
+  toggleSidebar() {
+    if (this.sidebar.classList.contains('open')) {
+      this.closeSidebar();
+    } else {
+      this.openSidebar();
+    }
+  }
+
+  openSidebar() {
+    this.sidebar.classList.add('open');
+    this.overlay.classList.add('show');
+    this.hamburger.classList.add('active');
+    document.body.style.overflow = 'hidden';
+  }
+
+  closeSidebar() {
+    this.sidebar.classList.remove('open');
+    this.overlay.classList.remove('show');
+    this.hamburger.classList.remove('active');
+    document.body.style.overflow = '';
+  }
+
+  setActiveNav() {
+    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
+    this.navItems.forEach(item => item.classList.remove('active'));
+    if (currentPage === 'index.html' || currentPage === '') {
+      this.querySelector('#nav-home')?.classList.add('active');
+    } else if (currentPage === 'Notepad.html') {
+      this.querySelector('#nav-notepad')?.classList.add('active');
+    } else if (currentPage === 'Project.html') {
+      this.querySelector('#nav-projects')?.classList.add('active');
+    }
+  }
+}
+
+customElements.define('mugen-menu', MugenMenu);

--- a/index.html
+++ b/index.html
@@ -9,41 +9,7 @@
     <link rel="stylesheet" href="css/master.css">
 </head>
 <body class="index-page">
-    <!-- Hamburger Menu -->
-    <div class="hamburger-menu" id="hamburgerMenu">
-        <div class="hamburger" id="hamburger">
-            <span></span>
-            <span></span>
-            <span></span>
-        </div>
-    </div>
-
-    <!-- Sidebar Navigation -->
-    <div class="sidebar-overlay" id="sidebarOverlay"></div>
-    <nav class="sidebar" id="sidebar">
-        <div class="sidebar-header">
-            <div class="sidebar-logo">MugenOs</div>
-            <div class="sidebar-subtitle">無限 Sistema</div>
-        </div>
-        <div class="nav-menu">
-                        <a href="index.html" class="nav-item active" id="nav-home">
-                <i>🏠</i> Início
-            </a>
-            <a href="Notepad.html" class="nav-item" id="nav-notepad">
-                <i>📝</i> Anotações
-            </a>
-            <a href="Project.html" class="nav-item" id="nav-projects">
-                <i>📋</i> Projetos
-            </a>
-
-            <a href="#" class="nav-item" id="nav-expenses" style="opacity: 0.5; pointer-events: none;">
-                <i>💰</i> Despesas <small>(em breve)</small>
-            </a>
-            <a href="#" class="nav-item" id="nav-calendar" style="opacity: 0.5; pointer-events: none;">
-                <i>📅</i> Compromissos <small>(em breve)</small>
-            </a>
-        </div>
-    </nav>
+    <mugen-menu></mugen-menu>
 
     <!-- Animated background particles -->
     <div class="particles">
@@ -96,6 +62,7 @@
             </div>
         </div>
     </div>
+    <script src="components/mugen-menu.js"></script>
     <script src='js/app.js' defer></script>
 
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -1,67 +1,3 @@
-class MugenNavigation {
-  constructor() {
-    this.cacheDOM();
-    this.bindEvents();
-    this.setActiveNav();
-  }
-
-  cacheDOM() {
-    this.hamburgerMenu = document.getElementById('hamburgerMenu');
-    this.hamburger = document.getElementById('hamburger');
-    this.sidebar = document.getElementById('sidebar');
-    this.overlay = document.getElementById('sidebarOverlay');
-    this.navItems = document.querySelectorAll('.nav-item');
-  }
-
-  bindEvents() {
-    if (!this.hamburgerMenu) return;
-    this.hamburgerMenu.addEventListener('click', () => this.toggleSidebar());
-    this.overlay.addEventListener('click', () => this.closeSidebar());
-    this.navItems.forEach(item => {
-      item.addEventListener('click', () => {
-        if (!item.style.pointerEvents) this.closeSidebar();
-      });
-    });
-    document.addEventListener('keydown', e => {
-      if (e.key === 'Escape') this.closeSidebar();
-    });
-  }
-
-  toggleSidebar() {
-    if (this.sidebar.classList.contains('open')) {
-      this.closeSidebar();
-    } else {
-      this.openSidebar();
-    }
-  }
-
-  openSidebar() {
-    this.sidebar.classList.add('open');
-    this.overlay.classList.add('show');
-    this.hamburger.classList.add('active');
-    document.body.style.overflow = 'hidden';
-  }
-
-  closeSidebar() {
-    this.sidebar.classList.remove('open');
-    this.overlay.classList.remove('show');
-    this.hamburger.classList.remove('active');
-    document.body.style.overflow = '';
-  }
-
-  setActiveNav() {
-    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-    this.navItems.forEach(item => item.classList.remove('active'));
-    if (currentPage === 'index.html' || currentPage === '') {
-      document.getElementById('nav-home')?.classList.add('active');
-    } else if (currentPage === 'Notepad.html') {
-      document.getElementById('nav-notepad')?.classList.add('active');
-    } else if (currentPage === 'Project.html') {
-      document.getElementById('nav-projects')?.classList.add('active');
-    }
-  }
-}
-
 class MugenNotepad {
   constructor() {
     this.STORAGE_KEY = 'mugenNotepadData';
@@ -506,7 +442,6 @@ function initIndexPage() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  window.mugenNav = new MugenNavigation();
   if (document.getElementById('notepadTextarea')) {
     window.mugenNotepad = new MugenNotepad();
   }


### PR DESCRIPTION
## Summary
- extract navigation markup and logic into `components/mugen-menu.js`
- replace duplicated menu HTML in pages with `<mugen-menu>` element
- remove old navigation class from `js/app.js`
- load new component on all pages

## Testing
- `node --check components/mugen-menu.js`
- `node --check js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_686ff7090c088321b907381017290f57