### PR TITLE
Add Batman theme selector

### DIFF
--- a/Notepad.html
+++ b/Notepad.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>♾️</text></svg>">
     <link rel="stylesheet" href="css/master.css">
 </head>
-<body class="app-page">
+<body class="app-page theme-purple">
     <mugen-menu></mugen-menu>
 
     <!-- Main Content -->

--- a/Project.html
+++ b/Project.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>♾️</text></svg>">
     <link rel="stylesheet" href="css/master.css">
 </head>
-<body class="app-page">
+<body class="app-page theme-purple">
     <mugen-menu></mugen-menu>
 
     <!-- Main Content -->

--- a/components/mugen-menu.js
+++ b/components/mugen-menu.js
@@ -36,10 +36,24 @@ class MugenMenu extends HTMLElement {
                 <i>📅</i> Compromissos <small>(em breve)</small>
             </a>
         </div>
-    </nav>`;
+        <div class="theme-selector">
+          <div class="theme-label">Temas</div>
+          <div class="theme-options">
+            <div class="theme-option active" data-theme="purple">
+              <div class="theme-preview theme-purple"></div>
+              <span>MugenOs</span>
+            </div>
+            <div class="theme-option" data-theme="batman">
+              <div class="theme-preview theme-batman"></div>
+              <span>BatmanOs</span>
+            </div>
+          </div>
+        </div>
+      </nav>`;
     this.cacheDOM();
     this.bindEvents();
     this.setActiveNav();
+    this.loadTheme();
   }
 
   cacheDOM() {
@@ -48,6 +62,7 @@ class MugenMenu extends HTMLElement {
     this.sidebar = this.querySelector('#sidebar');
     this.overlay = this.querySelector('#sidebarOverlay');
     this.navItems = this.querySelectorAll('.nav-item');
+    this.themeOptions = this.querySelectorAll('.theme-option');
   }
 
   bindEvents() {
@@ -57,6 +72,13 @@ class MugenMenu extends HTMLElement {
     this.navItems.forEach(item => {
       item.addEventListener('click', () => {
         if (!item.style.pointerEvents) this.closeSidebar();
+      });
+    });
+    this.themeOptions.forEach(opt => {
+      opt.addEventListener('click', () => {
+        const theme = opt.dataset.theme;
+        this.applyTheme(theme);
+        this.saveTheme(theme);
       });
     });
     this._handleKeyDown = (e) => {
@@ -101,6 +123,40 @@ class MugenMenu extends HTMLElement {
     } else if (currentPage === 'Project.html') {
       this.querySelector('#nav-projects')?.classList.add('active');
     }
+  }
+
+  loadTheme() {
+    const savedTheme = localStorage.getItem('mugenThemePreference') || 'purple';
+    this.applyTheme(savedTheme);
+  }
+
+  applyTheme(themeName) {
+    document.body.classList.remove('theme-purple', 'theme-batman');
+    document.body.classList.add(`theme-${themeName}`);
+    this.updateThemeSelector(themeName);
+    this.updateBranding(themeName);
+  }
+
+  updateThemeSelector(themeName) {
+    this.themeOptions.forEach(opt => {
+      opt.classList.toggle('active', opt.dataset.theme === themeName);
+    });
+  }
+
+  updateBranding(themeName) {
+    const logo = this.querySelector('.sidebar-logo');
+    const subtitle = this.querySelector('.sidebar-subtitle');
+    const isBatman = themeName === 'batman';
+    logo.textContent = isBatman ? 'BatmanOs' : 'MugenOs';
+    subtitle.textContent = isBatman ? '🦇 Sistema' : '無限 Sistema';
+    const heroTitle = document.querySelector('.logo .title');
+    if (heroTitle) heroTitle.textContent = isBatman ? 'BatmanOs' : 'MugenOs';
+    const heroSubtitle = document.querySelector('.logo .subtitle');
+    if (heroSubtitle) heroSubtitle.textContent = isBatman ? '🦇 Sistema' : 'Sistema Infinito';
+  }
+
+  saveTheme(themeName) {
+    localStorage.setItem('mugenThemePreference', themeName);
   }
 }
 

--- a/css/master.css
+++ b/css/master.css
@@ -7,6 +7,51 @@
     --card-bg: #1a1614;
     --input-bg: #252018;
     --success-green: #27ae60;
+    /* Core Batman Colors */
+    --batman-black: #000000;
+    --batman-dark-gray: #1C1C1C;
+    --batman-gray: #2F2F2F;
+    --batman-gold: #FFD700;
+    --batman-gold-orange: #FFA500;
+    --batman-yellow: #FFFF00;
+    --batman-medium-gray: #808080;
+    --batman-light-gray: #C0C0C0;
+    --batman-white: #FFFFFF;
+    --theme-primary: #A523D9;
+    --theme-secondary: #7d1aa0;
+    --theme-background: #100C08;
+    --theme-cards: #1a1614;
+}
+
+body.theme-purple {
+    --theme-primary: #A523D9;
+    --theme-secondary: #7d1aa0;
+    --theme-background: #100C08;
+    --theme-cards: #1a1614;
+    --ghostwhite: #F8F8FF;
+    --smoky-black: #100C08;
+    --meteorite-purple: #A523D9;
+    --border-color: #333;
+    --card-bg: #1a1614;
+    --input-bg: #252018;
+    --purple-glow: rgba(165, 35, 217, 0.5);
+}
+
+body.theme-batman {
+    --theme-primary: var(--batman-gold);
+    --theme-secondary: var(--batman-gold-orange);
+    --theme-background: var(--batman-dark-gray);
+    --theme-cards: var(--batman-gray);
+    --ghostwhite: var(--batman-light-gray);
+    --smoky-black: var(--batman-dark-gray);
+    --meteorite-purple: var(--batman-gold);
+    --border-color: var(--batman-gray);
+    --card-bg: var(--batman-gray);
+    --input-bg: var(--batman-black);
+    --purple-glow: rgba(255, 215, 0, 0.5);
+    --theme-accent: var(--batman-yellow);
+    --theme-text: var(--batman-light-gray);
+    --theme-border: var(--batman-gray);
 }
 
 * {
@@ -339,6 +384,47 @@ body.app-page {
 
 .nav-menu {
     padding: 20px 0;
+}
+
+.theme-selector {
+    padding: 20px 25px;
+    border-top: 1px solid var(--border-color);
+}
+
+.theme-options {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.theme-option {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 10px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.theme-option.active {
+    box-shadow: 0 0 0 2px var(--meteorite-purple);
+}
+
+.theme-preview {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    margin-bottom: 5px;
+}
+
+.theme-purple {
+    background: linear-gradient(45deg, #A523D9, #7d1aa0);
+}
+
+.theme-batman {
+    background: linear-gradient(45deg, var(--batman-gold), var(--batman-black));
+    border: 1px solid var(--batman-gold);
 }
 
 .nav-item {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <title>MugenOs - Sistema Infinito</title>
     <link rel="stylesheet" href="css/master.css">
 </head>
-<body class="index-page">
+<body class="index-page theme-purple">
     <mugen-menu></mugen-menu>
 
     <!-- Animated background particles -->


### PR DESCRIPTION
## Summary
- implement global theme variables and Batman theme colors
- add theme selector to sidebar
- persist theme preference in localStorage
- update body classes and branding dynamically
- default pages start with purple theme

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6870ee8c5c048321b898a198a78a4133