### PR TITLE
Add missing styles for UI elements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -129,6 +129,17 @@ a:hover {
     border-color: var(--accent-fg);
 }
 
+.nav-item--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.nav-item--disabled:hover {
+    transform: none;
+    box-shadow: var(--shadow-small);
+    border-color: var(--border-default);
+}
+
 .btn {
     background: #21262d;
     color: var(--fg-default);
@@ -320,11 +331,42 @@ a:hover {
     padding: 8px;
     border-radius: 6px;
 }
+.date-label {
+    font-size: 10px;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.project-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.project-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+.steps-list {
+    list-style: none;
+    padding: 0;
+    margin: 12px 0;
+}
 .progress-bar {
+    width: 100%;
+    height: 8px;
     background: var(--bg-muted);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 8px;
 }
 
 .progress-fill {
+    height: 100%;
+    border-radius: 4px;
     transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
     background: linear-gradient(90deg, var(--accent-fg), #79c0ff);
     position: relative;
@@ -342,6 +384,9 @@ a:hover {
     animation: shimmer 2s infinite;
 }
 .step-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     padding: var(--space-sm) 0;
     transition: all 0.2s ease;
 }
@@ -384,6 +429,15 @@ a:hover {
 
 /* --- Modal --- */
 .modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
     background: rgba(1,4,9,0.8);
     backdrop-filter: blur(8px);
 }
@@ -400,6 +454,20 @@ a:hover {
     animation: modalSlideIn 0.3s ease-out;
     max-height: 90vh;
     overflow-y: auto;
+}
+
+.close-btn {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    font-size: 24px;
+    cursor: pointer;
+    color: var(--fg-muted);
+    transition: color 0.2s;
+}
+
+.close-btn:hover {
+    color: var(--fg-default);
 }
 
 /* Bloco de notas */
@@ -420,6 +488,21 @@ a:hover {
     justify-content: space-between;
     align-items: center;
     background: rgba(22, 27, 34, 0.5);
+}
+
+.notepad-footer {
+    padding: var(--space-md);
+    border-top: 1px solid var(--border-default);
+    display: flex;
+    justify-content: space-between;
+    background: rgba(22, 27, 34, 0.5);
+    font-size: 12px;
+    color: var(--fg-muted);
+}
+
+.notepad-title {
+    font-weight: 600;
+    font-size: 16px;
 }
 
 .notepad-textarea {
@@ -468,6 +551,10 @@ a:hover {
     transform: translateX(100%);
     transition: all 0.3s ease;
     z-index: 2000;
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    max-width: 300px;
 }
 .notification.show {
     opacity: 1;


### PR DESCRIPTION
## Summary
- add nav-item disabled styling
- style project headers, actions and lists
- expand progress bar rules
- style modal container and close button
- style notepad footer and title
- adjust notification positioning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876609d4f7c8321b381d8a066d5eb47