### PR TITLE
Refactor to web components

### DIFF
--- a/Notepad.html
+++ b/Notepad.html
@@ -11,38 +11,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <header class="header">
-        <nav class="nav">
-            <a href="index.html" class="nav-brand">MugenOs</a>
-            <div class="nav-links">
-                <a href="Notepad.html">Anotações</a>
-                <a href="Project.html">Projetos</a>
-            </div>
-        </nav>
-    </header>
+    <app-header></app-header>
 
-    <main class="container">
-        <div class="notepad-container">
-            <div class="notepad-header">
-                <div class="notepad-info">
-                    <span class="notepad-title">Suas Anotações</span>
-                </div>
-                <div class="auto-save-status" id="autoSaveStatus">Auto-save ativo</div>
-            </div>
+    <main class="container"><notepad-widget></notepad-widget></main>
 
-            <textarea
-                class="notepad-textarea"
-                id="notepadTextarea"
-                placeholder="Comece a escrever suas anotações aqui..."
-            ></textarea>
-
-            <div class="notepad-footer">
-                <div class="char-counter" id="charCounter">0 caracteres</div>
-                <div class="word-counter" id="wordCounter">0 palavras</div>
-            </div>
-        </div>
-    </main>
-
-    <script src="js/app.js" defer></script>
+    <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/Project.html
+++ b/Project.html
@@ -11,15 +11,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <header class="header">
-        <nav class="nav">
-            <a href="index.html" class="nav-brand">MugenOs</a>
-            <div class="nav-links">
-                <a href="Notepad.html">Anotações</a>
-                <a href="Project.html">Projetos</a>
-            </div>
-        </nav>
-    </header>
+    <app-header></app-header>
 
     <main class="container">
         <div class="page-header">
@@ -27,65 +19,14 @@
             <p class="page-subtitle">無限</p>
         </div>
 
-        <div class="stats" id="stats">
-            <div class="stat-card">
-                <div class="stat-number" id="totalProjects">0</div>
-                <div class="stat-label">Total de Projetos</div>
-            </div>
-            <div class="stat-card">
-                <div class="stat-number" id="completedProjects">0</div>
-                <div class="stat-label">Concluídos</div>
-            </div>
-            <div class="stat-card">
-                <div class="stat-number" id="pendingProjects">0</div>
-                <div class="stat-label">Em Andamento</div>
-            </div>
-        </div>
+        <project-stats></project-stats>
 
-        <div class="add-project">
-            <h2 style="margin-bottom: 20px;">Adicionar Novo Projeto</h2>
-            <form id="projectForm">
-                <div class="form-row">
-                    <div class="form-group"><label for="projectName">Nome do Projeto</label><input type="text" id="projectName" required></div>
-                    <div class="form-group"><label for="projectType">Tipo</label><select id="projectType" required><option value="">Selecione o tipo</option><option value="pessoal">Pessoal</option><option value="trabalho">Trabalho</option></select></div>
-                </div>
-                <div class="form-group"><label for="projectDescription">Descrição</label><textarea id="projectDescription" placeholder="Descreva o projeto..."></textarea></div>
-                <div class="form-row">
-                    <div class="form-group"><label for="startDate">Data de Início</label><input type="date" id="startDate" required></div>
-                    <div class="form-group"><label for="endDate">Data de Conclusão</label><input type="date" id="endDate" required></div>
-                </div>
-                <div class="form-group"><label for="projectSteps">Etapas do Projeto (uma por linha)</label><textarea id="projectSteps" placeholder="Etapa 1&#10;Etapa 2&#10;Etapa 3"></textarea></div>
-                <button type="submit" class="btn">Adicionar Projeto</button>
-            </form>
-        </div>
+        <add-project-form></add-project-form>
 
-        <div class="projects-grid" id="projectsGrid"></div>
+        <projects-list></projects-list>
     </main>
 
-    <div id="editModal" class="modal">
-        <div class="modal-content">
-            <span class="close-btn" id="closeModalBtn">&times;</span>
-            <h2>Editar Projeto</h2>
-            <form id="editForm" style="margin-top: 20px;">
-                <input type="hidden" id="editProjectId">
-                <div class="form-row">
-                    <div class="form-group"><label for="editProjectName">Nome do Projeto</label><input type="text" id="editProjectName" required></div>
-                    <div class="form-group"><label for="editProjectType">Tipo</label><select id="editProjectType" required><option value="">Selecione o tipo</option><option value="pessoal">Pessoal</option><option value="trabalho">Trabalho</option></select></div>
-                </div>
-                <div class="form-group"><label for="editProjectDescription">Descrição</label><textarea id="editProjectDescription" placeholder="Descreva o projeto..."></textarea></div>
-                <div class="form-row">
-                    <div class="form-group"><label for="editStartDate">Data de Início</label><input type="date" id="editStartDate" required></div>
-                    <div class="form-group"><label for="editEndDate">Data de Conclusão</label><input type="date" id="editEndDate" required></div>
-                </div>
-                <div class="form-group"><label for="editProjectSteps">Etapas do Projeto (uma por linha)</label><textarea id="editProjectSteps" placeholder="Etapa 1&#10;Etapa 2&#10;Etapa 3"></textarea></div>
-                <div style="display: flex; gap: 10px; justify-content: flex-end;">
-                    <button type="button" class="btn btn-danger" id="cancelEditBtn">Cancelar</button>
-                    <button type="submit" class="btn">Salvar Alterações</button>
-                </div>
-            </form>
-        </div>
-    </div>
-
-    <script src="js/app.js" defer></script>
+    <edit-project-modal></edit-project-modal>
+    <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,15 +12,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <header class="header">
-        <nav class="nav">
-            <a href="index.html" class="nav-brand">MugenOs</a>
-            <div class="nav-links">
-                <a href="Notepad.html">Anotações</a>
-                <a href="Project.html">Projetos</a>
-            </div>
-        </nav>
-    </header>
+    <app-header></app-header>
 
     <main class="container">
         <section class="hero">
@@ -49,7 +41,6 @@
             </div>
         </div>
     </main>
-
-    <script src="js/app.js" defer></script>
+    <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,396 +1,421 @@
-/**
- * MugenNotepad: Classe para gerir a funcionalidade do bloco de notas.
- */
-class MugenNotepad {
+/* MugenOs Web Components */
+
+class AppHeader extends HTMLElement {
   constructor() {
-    this.STORAGE_KEY = 'mugenNotepadData';
-    this.autoSaveTimeout = null;
-    // A inicialização só ocorre se os elementos necessários existirem.
-    if (this.cacheDOM()) {
-      this.bindEvents();
-      this.loadNote();
-      this.updateCounters();
-    }
+    super();
+    this.attachShadow({ mode: 'open' });
   }
 
-  cacheDOM() {
-    this.textarea = document.getElementById('notepadTextarea');
-    if (!this.textarea) return false; // Aborta se o elemento principal não for encontrado
-
-    this.charCounter = document.getElementById('charCounter');
-    this.wordCounter = document.getElementById('wordCounter');
-    this.autoSaveStatus = document.getElementById('autoSaveStatus');
-    return true;
+  connectedCallback() {
+    this.render();
   }
 
-  bindEvents() {
-    this.textarea.addEventListener('input', () => {
-      this.updateCounters();
-      this.scheduleAutoSave();
-    });
-  }
-
-  loadNote() {
-    try {
-      const savedNote = localStorage.getItem(this.STORAGE_KEY);
-      if (savedNote) {
-        this.textarea.value = savedNote;
-      }
-    } catch (error) {
-      console.error('Erro ao carregar anotação:', error);
-    }
-  }
-
-  saveNote() {
-    try {
-      localStorage.setItem(this.STORAGE_KEY, this.textarea.value);
-      this.showAutoSaveStatus('saved');
-    } catch (error) {
-      console.error('Erro ao salvar anotação:', error);
-      this.showAutoSaveStatus('error');
-    }
-  }
-
-  scheduleAutoSave() {
-    this.showAutoSaveStatus('saving');
-    if (this.autoSaveTimeout) {
-      clearTimeout(this.autoSaveTimeout);
-    }
-    this.autoSaveTimeout = setTimeout(() => {
-      this.saveNote();
-    }, 1500); // Aumentado o tempo para 1.5s
-  }
-
-  showAutoSaveStatus(status) {
-    if (!this.autoSaveStatus) return;
-    this.autoSaveStatus.className = 'auto-save-status';
-    switch (status) {
-      case 'saving':
-        this.autoSaveStatus.textContent = 'A guardar...';
-        this.autoSaveStatus.classList.add('saving');
-        break;
-      case 'saved':
-        this.autoSaveStatus.textContent = 'Guardado';
-        this.autoSaveStatus.classList.add('saved');
-        setTimeout(() => {
-          this.autoSaveStatus.textContent = 'Auto-save ativo';
-          this.autoSaveStatus.classList.remove('saved');
-        }, 2000);
-        break;
-      case 'error':
-        this.autoSaveStatus.textContent = 'Erro ao guardar';
-        break;
-    }
-  }
-
-  updateCounters() {
-    if (!this.textarea) return;
-    const text = this.textarea.value;
-    const charCount = text.length;
-    const wordCount = text.trim() ? text.trim().split(/\s+/).length : 0;
-    this.charCounter.textContent = `${charCount.toLocaleString()} caracteres`;
-    this.wordCounter.textContent = `${wordCount.toLocaleString()} palavras`;
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        .header{background:var(--bg-default);border-bottom:1px solid var(--border-default);position:sticky;top:0;z-index:10;}
+        .nav{display:flex;align-items:center;justify-content:space-between;max-width:1280px;margin:0 auto;padding:16px;}
+        .nav-brand{font-weight:600;font-size:20px;color:var(--fg-default);}
+        .nav-links a{margin-left:16px;padding:8px;color:var(--accent-fg);text-decoration:none;}
+        .nav-links a:hover{text-decoration:underline;}
+      </style>
+      <header class="header">
+        <nav class="nav">
+          <a href="index.html" class="nav-brand">MugenOs</a>
+          <div class="nav-links">
+            <a href="Notepad.html">Anotações</a>
+            <a href="Project.html">Projetos</a>
+          </div>
+        </nav>
+      </header>`;
   }
 }
+customElements.define('app-header', AppHeader);
 
-/**
- * ProjectOrganizer: Classe para gerir toda a lógica dos projetos.
- */
-class ProjectOrganizer {
+class ProjectCard extends HTMLElement {
   constructor() {
-    this.STORAGE_KEY = 'mugenProjectsData';
-    // A inicialização só ocorre se a página de projetos estiver ativa.
-    if (this.cacheDOM()) {
-      this.projects = this.loadFromLocalStorage() || [];
-      this.dateFormatter = new Intl.DateTimeFormat('pt-BR', {
-        day: '2-digit', month: '2-digit', year: 'numeric', timeZone: 'UTC'
-      });
-      this.bindEvents();
-      this.renderAll();
-    }
+    super();
+    this.attachShadow({ mode: 'open' });
   }
 
-  cacheDOM() {
-    this.dom = {};
-    this.dom.projectForm = document.getElementById('projectForm');
-    if (!this.dom.projectForm) return false; // Aborta se o formulário não existir
-
-    this.dom.projectsGrid = document.getElementById('projectsGrid');
-    this.dom.stats = {
-      total: document.getElementById('totalProjects'),
-      completed: document.getElementById('completedProjects'),
-      pending: document.getElementById('pendingProjects'),
-    };
-    this.dom.editModal = {
-      modal: document.getElementById('editModal'),
-      form: document.getElementById('editForm'),
-      closeBtn: document.getElementById('closeModalBtn'),
-      cancelBtn: document.getElementById('cancelEditBtn'),
-      id: document.getElementById('editProjectId'),
-      name: document.getElementById('editProjectName'),
-      type: document.getElementById('editProjectType'),
-      description: document.getElementById('editProjectDescription'),
-      startDate: document.getElementById('editStartDate'),
-      endDate: document.getElementById('editEndDate'),
-      steps: document.getElementById('editProjectSteps'),
-    };
-    return true;
+  set project(value) {
+    this._project = value;
+    if (this.isConnected) this.render();
   }
 
-  bindEvents() {
-    this.dom.projectForm.addEventListener('submit', e => {
-      e.preventDefault();
-      this.addProject();
-    });
-
-    this.dom.projectsGrid.addEventListener('click', e => {
-      const target = e.target;
-      const editBtn = target.closest('.btn-edit');
-      const deleteBtn = target.closest('.btn-delete');
-
-      if (target.matches('.step-checkbox')) {
-        this.toggleStep(parseInt(target.dataset.projectId), parseInt(target.dataset.stepIndex));
-      } else if (editBtn) {
-        this.openEditModal(parseInt(editBtn.dataset.projectId));
-      } else if (deleteBtn) {
-        this.deleteProject(parseInt(deleteBtn.dataset.projectId));
-      }
-    });
-
-    this.dom.editModal.form.addEventListener('submit', e => {
-      e.preventDefault();
-      this.updateProject();
-    });
-    this.dom.editModal.closeBtn.addEventListener('click', () => this.closeEditModal());
-    this.dom.editModal.cancelBtn.addEventListener('click', () => this.closeEditModal());
-    this.dom.editModal.modal.addEventListener('click', e => {
-      if (e.target === this.dom.editModal.modal) {
-        this.closeEditModal();
-      }
-    });
+  get project() {
+    return this._project;
   }
 
-  renderAll() {
-    this.renderProjects();
-    this.updateStats();
+  connectedCallback() {
+    if (this._project) this.render();
   }
 
-  saveToLocalStorage(isSilent = false) {
-    try {
-      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(this.projects));
-      if (!isSilent) this.showNotification('Progresso guardado!', 'success');
-    } catch (error) {
-      console.error('Erro ao guardar no localStorage:', error);
-      if (!isSilent) this.showNotification('Erro ao guardar localmente.', 'error');
-    }
-  }
-
-  loadFromLocalStorage() {
-    try {
-      const data = localStorage.getItem(this.STORAGE_KEY);
-      return data ? JSON.parse(data) : [];
-    } catch (error) {
-      console.error('Erro ao carregar do localStorage:', error);
-      return [];
-    }
-  }
-
-  addProject() {
-    const form = this.dom.projectForm;
-    const name = form.querySelector('#projectName').value.trim();
-    const type = form.querySelector('#projectType').value;
-    const description = form.querySelector('#projectDescription').value.trim();
-    const startDate = form.querySelector('#startDate').value;
-    const endDate = form.querySelector('#endDate').value;
-    const stepsText = form.querySelector('#projectSteps').value.trim();
-
-    if (!name || !type || !startDate || !endDate) {
-      this.showNotification('Preencha os campos obrigatórios.', 'error');
-      return;
-    }
-    if (new Date(endDate) < new Date(startDate)) {
-      this.showNotification('A data de conclusão não pode ser anterior à de início.', 'error');
-      return;
-    }
-
-    const project = {
-      id: Date.now(),
-      name, type, description, startDate, endDate,
-      steps: stepsText ? stepsText.split('\n').map(text => ({ text: text.trim(), completed: false })).filter(s => s.text) : [],
-      createdAt: new Date().toISOString()
-    };
-
-    this.projects.push(project);
-    this.saveToLocalStorage();
-    this.renderAll();
-    form.reset();
-    this.showNotification('Projeto adicionado com sucesso!', 'success');
-  }
-
-  updateProject() {
-    const modal = this.dom.editModal;
-    const projectId = parseInt(modal.id.value);
-    const projectIndex = this.projects.findIndex(p => p.id === projectId);
-    if (projectIndex === -1) return;
-
-    const updatedData = {
-      name: modal.name.value.trim(),
-      type: modal.type.value,
-      description: modal.description.value.trim(),
-      startDate: modal.startDate.value,
-      endDate: modal.endDate.value,
-      steps: modal.steps.value.trim() ? modal.steps.value.trim().split('\n').map(text => ({ text: text.trim(), completed: false })) : [],
-    };
-
-    if (new Date(updatedData.endDate) < new Date(updatedData.startDate)) {
-      this.showNotification('A data de conclusão não pode ser anterior à de início.', 'error');
-      return;
-    }
-
-    const oldProject = this.projects[projectIndex];
-    updatedData.steps.forEach(newStep => {
-      const oldStep = oldProject.steps.find(s => s.text === newStep.text);
-      if (oldStep) newStep.completed = oldStep.completed;
-    });
-
-    this.projects[projectIndex] = { ...oldProject, ...updatedData };
-    this.saveToLocalStorage();
-    this.renderAll();
-    this.closeEditModal();
-    this.showNotification('Projeto atualizado!', 'info');
-  }
-
-  deleteProject(projectId) {
-    const project = this.projects.find(p => p.id === projectId);
-    if (project && confirm(`Tem a certeza que deseja apagar o projeto "${project.name}"?`)) {
-      this.projects = this.projects.filter(p => p.id !== projectId);
-      this.saveToLocalStorage();
-      this.renderAll();
-      this.showNotification('Projeto apagado!', 'warning');
-    }
-  }
-
-  toggleStep(projectId, stepIndex) {
-    const project = this.projects.find(p => p.id === projectId);
-    if (project && project.steps[stepIndex]) {
-      project.steps[stepIndex].completed = !project.steps[stepIndex].completed;
-      this.saveToLocalStorage(true);
-      this.renderAll();
-    }
-  }
-
-  openEditModal(projectId) {
-    const project = this.projects.find(p => p.id === projectId);
-    if (!project) return;
-    const modal = this.dom.editModal;
-    modal.id.value = project.id;
-    modal.name.value = project.name;
-    modal.type.value = project.type;
-    modal.description.value = project.description;
-    modal.startDate.value = project.startDate;
-    modal.endDate.value = project.endDate;
-    modal.steps.value = project.steps.map(s => s.text).join('\n');
-    modal.modal.style.display = 'flex';
-  }
-
-  closeEditModal() {
-    this.dom.editModal.modal.style.display = 'none';
-  }
-
-  renderProjects() {
-    this.projects.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)); // Mais recentes primeiro
-    this.dom.projectsGrid.innerHTML = this.projects.length > 0
-        ? this.projects.map(p => this.createProjectCard(p)).join('')
-        : '<div class="card" style="grid-column: 1 / -1; text-align: center; padding: 40px; color: var(--fg-muted);">Nenhum projeto adicionado ainda.</div>';
-  }
-
-  createProjectCard(project) {
-    const progress = this.calculateProgress(project.steps);
-    const { days, isOverdue } = this.calculateDaysRemaining(project.endDate);
+  render() {
+    const p = this._project;
+    const progress = this.calculateProgress(p.steps);
+    const { days, isOverdue } = this.calculateDaysRemaining(p.endDate);
     const overdueClass = isOverdue ? 'color: var(--danger-fg);' : '';
     const dateLabel = isOverdue ? 'Atrasado há' : 'Restam';
-
-    return `
-      <div class="card project-card" data-project-id="${project.id}">
+    this.shadowRoot.innerHTML = `
+      <style>
+        .card{background:linear-gradient(135deg,var(--bg-default) 0%,rgba(22,27,34,0.8) 100%);border:1px solid transparent;background-clip:padding-box;position:relative;gap:12px;padding:16px;border-radius:6px;display:flex;flex-direction:column;}
+        .card::before{content:'';position:absolute;inset:0;border-radius:6px;padding:1px;background:linear-gradient(135deg,var(--border-default),transparent);-webkit-mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);mask:linear-gradient(#fff 0 0) content-box,linear-gradient(#fff 0 0);-webkit-mask-composite:xor;mask-composite:exclude;}
+        .project-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;}
+        .project-title{font-weight:600;font-size:18px;}
+        .project-type{padding:2px 8px;border-radius:12px;font-size:12px;font-weight:500;text-transform:capitalize;border:1px solid;backdrop-filter:blur(10px);box-shadow:0 2px 4px rgba(0,0,0,0.2);}
+        .project-type.pessoal{color:#56d364;border-color:#56d364;background-color:rgba(56,139,69,0.15);}
+        .project-type.trabalho{color:#79c0ff;border-color:#79c0ff;background-color:rgba(57,133,228,0.15);}
+        .project-dates{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;font-size:12px;text-align:center;background:var(--bg-muted);padding:8px;border-radius:6px;}
+        .date-label{font-size:10px;color:var(--fg-muted);text-transform:uppercase;letter-spacing:0.5px;}
+        .project-actions{display:flex;gap:8px;margin-top:16px;}
+        .progress-bar{width:100%;height:8px;background:var(--bg-muted);border-radius:4px;overflow:hidden;margin-bottom:8px;}
+        .progress-fill{height:100%;border-radius:4px;transition:width 0.5s cubic-bezier(0.4,0,0.2,1);background:linear-gradient(90deg,var(--accent-fg),#79c0ff);position:relative;overflow:hidden;}
+        .steps-list{list-style:none;padding:0;margin:12px 0;}
+        .step-item{display:flex;align-items:center;gap:8px;padding:8px 0;transition:all 0.2s ease;}
+        .step-item.completed{opacity:0.6;}
+        .step-item.completed .step-text{text-decoration:line-through;color:var(--success-fg);}
+        .step-checkbox{appearance:none;width:20px;height:20px;border:2px solid var(--border-default);border-radius:4px;cursor:pointer;transition:all 0.2s ease;position:relative;}
+        .step-checkbox:checked{background:var(--success-fg);border-color:var(--success-fg);}
+        .step-checkbox:checked::after{content:'\2713';position:absolute;color:white;font-weight:bold;top:50%;left:50%;transform:translate(-50%,-50%);}
+        .btn{background:#21262d;color:var(--fg-default);border:1px solid var(--border-default);border-radius:6px;padding:8px 16px;font-size:14px;font-weight:500;cursor:pointer;transition:all 0.2s ease;}
+        .btn-danger{background:var(--danger-fg);border-color:var(--danger-fg);color:#fff;}
+      </style>
+      <div class="card">
         <div class="project-header">
-          <span class="project-title">${project.name}</span>
-          <span class="project-type ${project.type}">${project.type}</span>
+          <span class="project-title">${p.name}</span>
+          <span class="project-type ${p.type}">${p.type}</span>
         </div>
-        <p style="color: var(--fg-muted); flex-grow: 1;">${project.description || '<i>Sem descrição.</i>'}</p>
+        <p style="color:var(--fg-muted);flex-grow:1;">${p.description || '<i>Sem descrição.</i>'}</p>
         <div class="project-dates">
-          <div><span class="date-label">Início</span><br>${this.formatDate(project.startDate)}</div>
-          <div><span class="date-label">Fim</span><br>${this.formatDate(project.endDate)}</div>
+          <div><span class="date-label">Início</span><br>${this.formatDate(p.startDate)}</div>
+          <div><span class="date-label">Fim</span><br>${this.formatDate(p.endDate)}</div>
           <div style="${overdueClass}"><span class="date-label">${dateLabel}</span><br>${days} dia(s)</div>
         </div>
-        ${project.steps.length > 0 ? `
+        ${p.steps.length>0?`
         <div>
-          <div class="progress-bar"><div class="progress-fill" style="width: ${progress}%"></div></div>
-          <div style="font-size: 12px; color: var(--fg-muted);">${progress}% concluído</div>
+          <div class="progress-bar"><div class="progress-fill" style="width:${progress}%"></div></div>
+          <div style="font-size:12px;color:var(--fg-muted);">${progress}% concluído</div>
         </div>
         <ul class="steps-list">
-          ${project.steps.map((step, index) => `
-            <li class="step-item ${step.completed ? 'completed' : ''}">
-              <input type="checkbox" class="step-checkbox" data-project-id="${project.id}" data-step-index="${index}" ${step.completed ? 'checked' : ''}>
-              <span class="step-text">${step.text}</span>
-            </li>`).join('')}
-        </ul>` : ''}
+        ${p.steps.map((s,i)=>`<li class="step-item ${s.completed?'completed':''}"><input type="checkbox" class="step-checkbox" data-index="${i}" ${s.completed?'checked':''}><span class="step-text">${s.text}</span></li>`).join('')}
+        </ul>`:''}
         <div class="project-actions">
-          <button class="btn btn-edit" data-project-id="${project.id}">Editar</button>
-          <button class="btn btn-danger btn-delete" data-project-id="${project.id}">Apagar</button>
+          <button class="btn btn-edit">Editar</button>
+          <button class="btn btn-danger btn-delete">Apagar</button>
+        </div>
+      </div>`;
+
+    this.shadowRoot.querySelector('.btn-delete').addEventListener('click',()=>{
+      this.dispatchEvent(new CustomEvent('delete-project',{bubbles:true,detail:{projectId:p.id}}));
+    });
+    this.shadowRoot.querySelector('.btn-edit').addEventListener('click',()=>{
+      this.dispatchEvent(new CustomEvent('edit-project',{bubbles:true,detail:{projectId:p.id}}));
+    });
+    this.shadowRoot.querySelectorAll('.step-checkbox').forEach(cb=>{
+      cb.addEventListener('change',()=>{
+        const index=parseInt(cb.dataset.index);
+        this.dispatchEvent(new CustomEvent('toggle-step',{bubbles:true,detail:{projectId:p.id,stepIndex:index}}));
+      });
+    });
+  }
+
+  calculateProgress(steps){
+    if(!steps||!steps.length)return 0;
+    const completed=steps.filter(s=>s.completed).length;
+    return Math.round((completed/steps.length)*100);
+  }
+  formatDate(str){
+    if(!str)return 'N/A';
+    const date=new Date(str+'T00:00:00');
+    return new Intl.DateTimeFormat('pt-BR',{day:'2-digit',month:'2-digit',year:'numeric',timeZone:'UTC'}).format(date);
+  }
+  calculateDaysRemaining(end){
+    if(!end) return {days:0,isOverdue:false};
+    const now=new Date();
+    const today=new Date(now.getFullYear(),now.getMonth(),now.getDate());
+    const endDate=new Date(end+'T00:00:00');
+    const diff=Math.ceil((endDate-today)/(1000*3600*24));
+    return {days:Math.abs(diff),isOverdue:diff<0};
+  }
+}
+customElements.define('project-card',ProjectCard);
+
+class ProjectsList extends HTMLElement {
+  constructor(){
+    super();
+    this.attachShadow({mode:'open'});
+    this.projects=[];
+  }
+
+  connectedCallback(){
+    this.load();
+    this.render();
+    this.addEventListener('delete-project',e=>{this.deleteProject(e.detail.projectId);});
+    this.addEventListener('edit-project',e=>{this.dispatchEvent(new CustomEvent('edit-project',{bubbles:true,detail:e.detail}));});
+    this.addEventListener('toggle-step',e=>{this.toggleStep(e.detail.projectId,e.detail.stepIndex);});
+  }
+
+  load(){
+    try{this.projects=JSON.parse(localStorage.getItem('mugenProjectsData'))||[]}catch(e){this.projects=[];}
+  }
+
+  save(){
+    localStorage.setItem('mugenProjectsData',JSON.stringify(this.projects));
+  }
+
+  addProject(proj){
+    this.projects.push(proj);
+    this.save();
+    this.render();
+  }
+
+  updateProject(id,data){
+    const idx=this.projects.findIndex(p=>p.id===id);
+    if(idx>-1){this.projects[idx]={...this.projects[idx],...data};this.save();this.render();}
+  }
+
+  deleteProject(id){
+    this.projects=this.projects.filter(p=>p.id!==id);
+    this.save();
+    this.render();
+    this.dispatchEvent(new CustomEvent('projects-changed',{bubbles:true,detail:this.projects}));
+  }
+
+  toggleStep(pid,idx){
+    const p=this.projects.find(p=>p.id===pid);
+    if(p&&p.steps[idx]){p.steps[idx].completed=!p.steps[idx].completed;this.save();this.render();}
+  }
+
+  getProjectById(id){
+    return this.projects.find(p=>p.id===id);
+  }
+
+  render(){
+    this.shadowRoot.innerHTML=`
+      <style>
+        :host{display:block;}
+        .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px;}
+      </style>
+      <div class="grid"></div>`;
+    const grid=this.shadowRoot.querySelector('.grid');
+    if(this.projects.length===0){
+      grid.innerHTML='<div class="card" style="grid-column:1/-1;text-align:center;padding:40px;color:var(--fg-muted);">Nenhum projeto adicionado ainda.</div>';
+      return;
+    }
+    this.projects.sort((a,b)=>new Date(b.createdAt)-new Date(a.createdAt));
+    grid.innerHTML='';
+    this.projects.forEach(p=>{
+      const card=document.createElement('project-card');
+      card.project=p;
+      grid.appendChild(card);
+    });
+    this.dispatchEvent(new CustomEvent('projects-changed',{bubbles:true,detail:this.projects}));
+  }
+}
+customElements.define('projects-list',ProjectsList);
+
+class AddProjectForm extends HTMLElement {
+  constructor(){super();this.attachShadow({mode:'open'});}
+  connectedCallback(){this.render();}
+  render(){
+    this.shadowRoot.innerHTML=`
+      <style>
+        form{display:flex;flex-direction:column;gap:16px;}
+        .form-row{display:flex;gap:16px;}
+        .form-group{flex:1;display:flex;flex-direction:column;}
+        label{margin-bottom:8px;font-weight:500;color:var(--fg-muted);}
+        input,select,textarea{padding:8px 12px;border:1px solid var(--border-default);border-radius:6px;font-family:'Fira Code',monospace;font-size:14px;background-color:var(--bg-canvas);color:var(--fg-default);}
+        button{background:var(--accent-emphasis);color:#fff;border:1px solid var(--accent-emphasis);border-radius:6px;padding:8px 16px;font-weight:500;cursor:pointer;}
+      </style>
+      <h2 style="margin-bottom:20px;">Adicionar Novo Projeto</h2>
+      <form id="form">
+        <div class="form-row">
+          <div class="form-group"><label for="name">Nome do Projeto</label><input id="name" required></div>
+          <div class="form-group"><label for="type">Tipo</label><select id="type" required><option value="">Selecione o tipo</option><option value="pessoal">Pessoal</option><option value="trabalho">Trabalho</option></select></div>
+        </div>
+        <div class="form-group"><label for="desc">Descrição</label><textarea id="desc" placeholder="Descreva o projeto..."></textarea></div>
+        <div class="form-row">
+          <div class="form-group"><label for="start">Data de Início</label><input type="date" id="start" required></div>
+          <div class="form-group"><label for="end">Data de Conclusão</label><input type="date" id="end" required></div>
+        </div>
+        <div class="form-group"><label for="steps">Etapas do Projeto (uma por linha)</label><textarea id="steps" placeholder="Etapa 1\nEtapa 2\nEtapa 3"></textarea></div>
+        <button type="submit">Adicionar Projeto</button>
+      </form>`;
+    this.shadowRoot.querySelector('#form').addEventListener('submit',e=>{
+      e.preventDefault();
+      const name=this.shadowRoot.querySelector('#name').value.trim();
+      const type=this.shadowRoot.querySelector('#type').value;
+      const description=this.shadowRoot.querySelector('#desc').value.trim();
+      const startDate=this.shadowRoot.querySelector('#start').value;
+      const endDate=this.shadowRoot.querySelector('#end').value;
+      const stepsText=this.shadowRoot.querySelector('#steps').value.trim();
+      if(!name||!type||!startDate||!endDate)return;
+      if(new Date(endDate)<new Date(startDate))return;
+      const project={name,type,description,startDate,endDate,steps:stepsText?stepsText.split('\n').map(t=>({text:t.trim(),completed:false})).filter(s=>s.text):[]};
+      this.dispatchEvent(new CustomEvent('project-added',{bubbles:true,detail:project}));
+      this.shadowRoot.querySelector('#form').reset();
+    });
+  }
+}
+customElements.define('add-project-form',AddProjectForm);
+
+class ProjectStats extends HTMLElement {
+  constructor(){super();this.attachShadow({mode:'open'});}
+  set projects(arr){this._projects=arr||[];if(this.isConnected)this.render();}
+  get projects(){return this._projects||[];}
+  connectedCallback(){this.render();}
+  render(){
+    const total=this.projects.length;
+    const completed=this.projects.filter(p=>p.steps&&p.steps.every(s=>s.completed)).length;
+    const pending=total-completed;
+    this.shadowRoot.innerHTML=`
+      <style>
+        .stats{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-bottom:24px;}
+        .stat-card{background:var(--bg-default);padding:16px;border-radius:6px;border:1px solid var(--border-default);text-align:center;}
+        .stat-number{font-size:24px;font-weight:600;}
+      </style>
+      <div class="stats">
+        <div class="stat-card"><div class="stat-number">${total}</div><div class="stat-label">Total de Projetos</div></div>
+        <div class="stat-card"><div class="stat-number">${completed}</div><div class="stat-label">Concluídos</div></div>
+        <div class="stat-card"><div class="stat-number">${pending}</div><div class="stat-label">Em Andamento</div></div>
+      </div>`;
+  }
+}
+customElements.define('project-stats',ProjectStats);
+
+class EditProjectModal extends HTMLElement {
+  constructor(){super();this.attachShadow({mode:'open'});this._visible=false;}
+  connectedCallback(){this.render();}
+  render(){
+    this.shadowRoot.innerHTML=`
+      <style>
+        .modal{display:${this._visible?'flex':'none'};position:fixed;top:0;left:0;width:100%;height:100%;align-items:center;justify-content:center;z-index:1000;background:rgba(1,4,9,0.8);backdrop-filter:blur(8px);}
+        .modal-content{background:var(--bg-default);padding:24px;border-radius:6px;border:1px solid var(--border-default);box-shadow:var(--shadow-medium);width:90%;max-width:600px;max-height:90vh;overflow-y:auto;position:relative;animation:modalSlideIn 0.3s ease-out;}
+        .close-btn{position:absolute;top:16px;right:16px;font-size:24px;cursor:pointer;color:var(--fg-muted);}
+        form{display:flex;flex-direction:column;gap:16px;margin-top:20px;}
+        .form-row{display:flex;gap:16px;}
+        .form-group{flex:1;display:flex;flex-direction:column;}
+        label{margin-bottom:8px;font-weight:500;color:var(--fg-muted);}
+        input,select,textarea{padding:8px 12px;border:1px solid var(--border-default);border-radius:6px;font-family:'Fira Code',monospace;font-size:14px;background-color:var(--bg-canvas);color:var(--fg-default);}
+        button{background:var(--accent-emphasis);color:#fff;border:1px solid var(--accent-emphasis);border-radius:6px;padding:8px 16px;font-weight:500;cursor:pointer;}
+        .danger{background:var(--danger-fg);border-color:var(--danger-fg);}
+      </style>
+      <div class="modal">
+        <div class="modal-content">
+          <span class="close-btn">&times;</span>
+          <h2>Editar Projeto</h2>
+          <form id="form">
+            <input type="hidden" id="pid">
+            <div class="form-row">
+              <div class="form-group"><label for="name">Nome do Projeto</label><input id="name" required></div>
+              <div class="form-group"><label for="type">Tipo</label><select id="type" required><option value="">Selecione o tipo</option><option value="pessoal">Pessoal</option><option value="trabalho">Trabalho</option></select></div>
+            </div>
+            <div class="form-group"><label for="desc">Descrição</label><textarea id="desc" placeholder="Descreva o projeto..."></textarea></div>
+            <div class="form-row">
+              <div class="form-group"><label for="start">Data de Início</label><input type="date" id="start" required></div>
+              <div class="form-group"><label for="end">Data de Conclusão</label><input type="date" id="end" required></div>
+            </div>
+            <div class="form-group"><label for="steps">Etapas do Projeto (uma por linha)</label><textarea id="steps" placeholder="Etapa 1\nEtapa 2\nEtapa 3"></textarea></div>
+            <div style="display:flex;gap:10px;justify-content:flex-end;">
+              <button type="button" class="danger" id="cancel">Cancelar</button>
+              <button type="submit">Salvar Alterações</button>
+            </div>
+          </form>
+        </div>
+      </div>`;
+    this.shadowRoot.querySelector('.close-btn').addEventListener('click',()=>this.hide());
+    this.shadowRoot.querySelector('#cancel').addEventListener('click',()=>this.hide());
+    this.shadowRoot.querySelector('#form').addEventListener('submit',e=>{
+      e.preventDefault();
+      const data={
+        name:this.shadowRoot.querySelector('#name').value.trim(),
+        type:this.shadowRoot.querySelector('#type').value,
+        description:this.shadowRoot.querySelector('#desc').value.trim(),
+        startDate:this.shadowRoot.querySelector('#start').value,
+        endDate:this.shadowRoot.querySelector('#end').value,
+        steps:this.shadowRoot.querySelector('#steps').value.trim()?this.shadowRoot.querySelector('#steps').value.trim().split('\n').map(t=>({text:t.trim(),completed:false})):[]
+      };
+      const id=parseInt(this.shadowRoot.querySelector('#pid').value);
+      if(new Date(data.endDate)<new Date(data.startDate))return;
+      this.dispatchEvent(new CustomEvent('project-updated',{bubbles:true,detail:{projectId:id,data}}));
+      this.hide();
+    });
+  }
+  open(project){
+    this._visible=true;
+    this.render();
+    this.shadowRoot.querySelector('#pid').value=project.id;
+    this.shadowRoot.querySelector('#name').value=project.name;
+    this.shadowRoot.querySelector('#type').value=project.type;
+    this.shadowRoot.querySelector('#desc').value=project.description;
+    this.shadowRoot.querySelector('#start').value=project.startDate;
+    this.shadowRoot.querySelector('#end').value=project.endDate;
+    this.shadowRoot.querySelector('#steps').value=project.steps.map(s=>s.text).join('\n');
+  }
+  hide(){
+    this._visible=false;
+    this.render();
+  }
+}
+customElements.define('edit-project-modal',EditProjectModal);
+
+class NotepadWidget extends HTMLElement {
+  constructor(){super();this.attachShadow({mode:'open'});this.STORAGE_KEY='mugenNotepadData';this.autoSaveTimeout=null;}
+  connectedCallback(){this.render();this.loadNote();this.updateCounters();this.shadowRoot.querySelector('textarea').addEventListener('input',()=>{this.updateCounters();this.scheduleAutoSave();});}
+  render(){
+    this.shadowRoot.innerHTML=`
+      <style>
+        .container{background:var(--bg-default);border-radius:8px;border:1px solid var(--border-default);display:flex;flex-direction:column;height:calc(100vh - 140px);box-shadow:0 4px 6px rgba(0,0,0,0.1);}
+        .header{padding:16px;border-bottom:1px solid var(--border-default);display:flex;justify-content:space-between;align-items:center;background:rgba(22,27,34,0.5);}
+        .footer{padding:16px;border-top:1px solid var(--border-default);display:flex;justify-content:space-between;background:rgba(22,27,34,0.5);font-size:12px;color:var(--fg-muted);}
+        textarea{flex:1;border:1px solid var(--border-default);border-radius:6px;padding:24px;resize:vertical;font-family:'Fira Code',monospace;font-size:16px;background-color:var(--bg-default);color:var(--fg-default);}
+        textarea::placeholder{color:var(--fg-muted);opacity:0.5;}
+        .status{font-size:12px;color:var(--fg-muted);display:flex;align-items:center;gap:8px;}
+        .status.saving::before{content:'';width:8px;height:8px;border-radius:50%;background:var(--accent-fg);animation:pulse 1s infinite;}
+        @keyframes pulse{0%,100%{opacity:0.3;transform:scale(0.8);}50%{opacity:1;transform:scale(1);}}
+      </style>
+      <div class="container">
+        <div class="header">
+          <span class="title">Suas Anotações</span>
+          <div class="status" id="status">Auto-save ativo</div>
+        </div>
+        <textarea id="text" placeholder="Comece a escrever suas anotações aqui..."></textarea>
+        <div class="footer">
+          <div class="chars" id="chars">0 caracteres</div>
+          <div class="words" id="words">0 palavras</div>
         </div>
       </div>`;
   }
-
-  updateStats() {
-    const total = this.projects.length;
-    const completed = this.projects.filter(p => this.calculateProgress(p.steps) === 100).length;
-    this.dom.stats.total.textContent = total;
-    this.dom.stats.completed.textContent = completed;
-    this.dom.stats.pending.textContent = total - completed;
-  }
-
-  showNotification(message, type = 'success') {
-    const notification = document.createElement('div');
-    notification.className = `notification ${type} show`;
-    notification.textContent = message;
-    document.body.appendChild(notification);
-    setTimeout(() => {
-      notification.classList.remove('show');
-      notification.addEventListener('transitionend', () => notification.remove());
-    }, 4000);
-  }
-
-  formatDate(dateString) {
-    if (!dateString) return 'N/A';
-    const date = new Date(dateString + 'T00:00:00'); // Trata a data como local
-    return this.dateFormatter.format(date);
-  }
-
-  calculateProgress(steps) {
-    if (!steps || steps.length === 0) return 0;
-    const completed = steps.filter(step => step.completed).length;
-    return Math.round((completed / steps.length) * 100);
-  }
-
-  calculateDaysRemaining(endDateStr) {
-    if (!endDateStr) return { days: 0, isOverdue: false };
-    const now = new Date();
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const endDate = new Date(endDateStr + 'T00:00:00');
-    const dayDiff = Math.ceil((endDate - today) / (1000 * 3600 * 24));
-    return { days: Math.abs(dayDiff), isOverdue: dayDiff < 0 };
-  }
+  loadNote(){try{const saved=localStorage.getItem(this.STORAGE_KEY);if(saved){this.shadowRoot.querySelector('#text').value=saved;}}catch(e){console.error(e);} }
+  saveNote(){try{localStorage.setItem(this.STORAGE_KEY,this.shadowRoot.querySelector('#text').value);this.showStatus('saved');}catch(e){console.error(e);this.showStatus('error');}}
+  scheduleAutoSave(){this.showStatus('saving');if(this.autoSaveTimeout)clearTimeout(this.autoSaveTimeout);this.autoSaveTimeout=setTimeout(()=>this.saveNote(),1500);}
+  showStatus(s){const el=this.shadowRoot.querySelector('#status');el.className='status';switch(s){case'saving':el.textContent='A guardar...';el.classList.add('saving');break;case'saved':el.textContent='Guardado';setTimeout(()=>{el.textContent='Auto-save ativo';el.classList.remove('saved');},2000);break;case'error':el.textContent='Erro ao guardar';break;}}
+  updateCounters(){const text=this.shadowRoot.querySelector('#text').value;const chars=text.length;const words=text.trim()?text.trim().split(/\s+/).length:0;this.shadowRoot.querySelector('#chars').textContent=`${chars.toLocaleString()} caracteres`;this.shadowRoot.querySelector('#words').textContent=`${words.toLocaleString()} palavras`;}
 }
+customElements.define('notepad-widget',NotepadWidget);
 
-/**
- * Ponto de entrada da aplicação.
- * Ouve o evento 'DOMContentLoaded' para garantir que o DOM está pronto.
- * Instancia a classe correta dependendo da página atual.
- */
-document.addEventListener('DOMContentLoaded', () => {
-  // Tenta inicializar ambas as classes.
-  // A lógica interna de cada classe irá garantir que ela só é executada
-  // se os seus elementos HTML específicos existirem na página.
-  new MugenNotepad();
-  new ProjectOrganizer();
+/* Orchestrate components on each page */
+document.addEventListener('DOMContentLoaded',()=>{
+  const projectsList=document.querySelector('projects-list');
+  const addForm=document.querySelector('add-project-form');
+  const stats=document.querySelector('project-stats');
+  const modal=document.querySelector('edit-project-modal');
+  if(projectsList){
+    stats.projects=projectsList.projects;
+    projectsList.addEventListener('projects-changed',e=>{stats.projects=e.detail;});
+    addForm.addEventListener('project-added',e=>{
+      const project={...e.detail,id:Date.now(),createdAt:new Date().toISOString()};
+      projectsList.addProject(project);
+      stats.projects=projectsList.projects;
+    });
+    projectsList.addEventListener('edit-project',e=>{
+      const project=projectsList.getProjectById(e.detail.projectId);
+      modal.open(project);
+    });
+    modal.addEventListener('project-updated',e=>{
+      projectsList.updateProject(e.detail.projectId,e.detail.data);
+      stats.projects=projectsList.projects;
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- implement web components architecture for MugenOs
- replace page elements with `<app-header>`, `<project-stats>`, `<add-project-form>`, `<projects-list>`, `<edit-project-modal>` and `<notepad-widget>`
- update main script to define custom elements and orchestrate interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687782261ddc8321b87ebef7ddbbd5cf